### PR TITLE
fix: more than 3 testimonials break UI

### DIFF
--- a/app/components/landing/Testimonials.vue
+++ b/app/components/landing/Testimonials.vue
@@ -19,7 +19,7 @@ defineProps<{
       loop
       dots
       :ui="{
-        viewport: '-mx-4 sm:-mx-12 lg:-mx-16 bg-elevated/50'
+        viewport: '-mx-4 sm:-mx-12 lg:-mx-16 bg-elevated/50 max-w-(--ui-container)'
       }"
     >
       <UPageCTA


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

If you add more than 3 testimonials, the UI breaks on desktop: 

![image](https://github.com/user-attachments/assets/74438577-2a7a-44e6-8b13-9a9210360eb7)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Apply `max-w-(--ui-container)` on Carousel's viewport to avoid unexpected width on desktop screens.
