### PR TITLE
fix: article link

### DIFF
--- a/app/pages/blog/[...slug].vue
+++ b/app/pages/blog/[...slug].vue
@@ -39,7 +39,7 @@ useSeoMeta({
   ogTitle: title
 })
 
-const articleLink = computed(() => `${window.location}${route.path}`)
+const articleLink = computed(() => `${window?.location}`)
 
 const formatDate = (dateString: Date) => {
   return new Date(dateString).toLocaleDateString('en-US', {


### PR DESCRIPTION
### 🔗 Linked issue
The `articleLink` computed variable is returning a wrong link.
`window.location` is already returning the full link, no need to use `route.path`.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
